### PR TITLE
Rename -hashOnly to -mode floret

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ See the [python docs](python/README.md).
 `floret` adds two additional command line options to `fasttext`:
 
 ```
-  -hashOnly           both word and char ngrams hashed only in buckets [false]
-  -hashCount          with hashOnly: number of hashes (1-4) per word / subword [1]
+  -mode               fasttext (default) or floret (word and char ngrams hashed in buckets) [fasttext]
+  -hashCount          floret mode only: number of hashes (1-4) per word/subword [1]
 ```
 
-With `-hashOnly`, the word entries are stored in the same table as the subword
-embeddings (buckets), reducing the size of the saved vector data.
+With `-mode floret`, the word entries are stored in the same table as the
+subword embeddings (buckets), reducing the size of the saved vector data.
 
 With `-hashCount 2`, each entry is stored as the sum of 2 rows in the internal
 subwords hash table. `floret` supports 1-4 hashes per entry in the embeddings
@@ -64,14 +64,14 @@ hashes per entry, and a compact table of 50K entries rather than the default of
 2M entries.
 
 ```bash
-floret cbow -dim 300 -minn 4 -maxn 5 -hashOnly -hashCount 2 -bucket 50000 \
+floret cbow -dim 300 -minn 4 -maxn 5 -mode floret -hashCount 2 -bucket 50000 \
 -input input.txt -output vectors
 ```
 
-With the `-hashOnly` option, floret will save an additional vector table with
-the file ending `.floret`. The format is very similar to `.vec` with a header
-line followed by one line per vector. The word tokens are replaced with the
-index of the row and the header is extended to contain all the relevant
+With the `-mode floret` option, floret will save an additional vector table
+with the file ending `.floret`. The format is very similar to `.vec` with a
+header line followed by one line per vector. The word tokens are replaced with
+the index of the row and the header is extended to contain all the relevant
 training settings needed to load this table in spaCy.
 
 To import this vector table in [spaCy](https://spacy.io) v3.2+:
@@ -107,9 +107,9 @@ the table. By representing each entry as the sum of multiple rows, where it's
 unlikely that two entries will collide on multiple hashes, most entries will
 end up with a distinct representation.
 
-With the settings `-minn 4 -maxn 5 -hashOnly -hashCount 2`, the embedding for
-the word `apple` is stored internally as the sum of 2 hashed rows for each of
-the word, 4-grams and 5-ngrams. The word is padded with the BOW and EOW
+With the settings `-minn 4 -maxn 5 -mode floret -hashCount 2`, the embedding
+for the word `apple` is stored internally as the sum of 2 hashed rows for each
+of the word, 4-grams and 5-ngrams. The word is padded with the BOW and EOW
 characters `<` and `>`, creating the following word and subword entries:
 
 ```
@@ -128,7 +128,7 @@ For compatibility with spaCy,
 char ngram strings. The final embedding for `apple` is then the sum of two rows
 (`-hashCount 2`) per word and char ngram above.
 
-With `-hashOnly`, `floret` will save an additional vector table with the
+With `-mode floret`, `floret` will save an additional vector table with the
 ending `.floret` alongside the usual `.bin` and `.vec` files. The format is
 very similar to `.vec` with a header line followed by one line per entry in the
 vector table with the row index rather than a word token at the beginning of

--- a/python/README.md
+++ b/python/README.md
@@ -19,8 +19,8 @@ pip install floret
 
 Train floret vectors using the options:
 
-- `hashOnly`: if `True`, train floret vectors, storing both words and subwords
-  in the same compact hash table
+- `mode`: `"floret"`, storing both words and subwords in the same compact hash
+  table
 - `hashCount`: store each entry in 1-4 rows in the hash table (recommended:
   `2`)
 - `bucket`: in combination with `hashCount>1`, the size of the hash table can
@@ -36,7 +36,7 @@ import floret
 model = floret.train_unsupervised(
     "data.txt",
     model="cbow",
-    hashOnly=True,
+    mode="floret",
     hashCount=2,
     bucket=50000,
     minn=3,
@@ -56,7 +56,7 @@ model.save_vectors("vectors.vec")
 model.save_hash_only_vectors("vectors.floret")
 ```
 
-**Note:** with the default setting `hashOnly=False`, `floret` trains original
+**Note:** with the default setting `mode="fasttext"`, `floret` trains original
 fastText vectors.
 
 ## Use floret vectors in spaCy

--- a/python/floret_module/floret/pybind/floret_pybind.cc
+++ b/python/floret_module/floret/pybind/floret_pybind.cc
@@ -104,7 +104,7 @@ PYBIND11_MODULE(floret_pybind, m) {
       .def_readwrite("bucket", &fasttext::Args::bucket)
       .def_readwrite("minn", &fasttext::Args::minn)
       .def_readwrite("maxn", &fasttext::Args::maxn)
-      .def_readwrite("hashOnly", &fasttext::Args::hashOnly)
+      .def_readwrite("mode", &fasttext::Args::mode)
       .def_readwrite("hashCount", &fasttext::Args::hashCount)
       .def_readwrite("thread", &fasttext::Args::thread)
       .def_readwrite("t", &fasttext::Args::t)
@@ -156,6 +156,11 @@ PYBIND11_MODULE(floret_pybind, m) {
           "recallAtPrecisionLabel",
           fasttext::metric_name::recallAtPrecisionLabel)
       .export_values();
+
+  py::enum_<fasttext::mode_name>(m, "mode_name")
+      .value("fasttext", fasttext::mode_name::fasttext)
+      .value("floret", fasttext::mode_name::floret);
+      // not exported into the parent scope because the names clash
 
   m.def(
       "train",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import platform
 import io
 import pybind11
 
-__version__ = '0.10.0.dev0'
+__version__ = '0.10.0.dev1'
 FASTTEXT_SRC = "src"
 
 # Based on https://github.com/pybind/python_example

--- a/src/args.h
+++ b/src/args.h
@@ -26,12 +26,14 @@ enum class metric_name : int {
   recallAtPrecision,
   recallAtPrecisionLabel
 };
+enum class mode_name : int { fasttext = 1, floret };
 
 class Args {
  protected:
   std::string boolToString(bool) const;
   std::string modelToString(model_name) const;
   std::string metricToString(metric_name) const;
+  std::string modeToString(mode_name) const;
   std::unordered_set<std::string> manualArgs_;
 
  public:
@@ -52,7 +54,7 @@ class Args {
   int bucket;
   int minn;
   int maxn;
-  bool hashOnly;
+  mode_name mode;
   int hashCount;
   int thread;
   double t;

--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -109,7 +109,7 @@ void Dictionary::getSubwords(
   int32_t i = getId(word);
   ngrams.clear();
   substrings.clear();
-  if (!args_->hashOnly && i >= 0) {
+  if (args_->mode != mode_name::floret && i >= 0) {
     ngrams.push_back(i);
     substrings.push_back(words_[i].word);
   }
@@ -183,7 +183,7 @@ void Dictionary::computeSubwords(
     const std::string& word,
     std::vector<int32_t>& ngrams,
     std::vector<std::string>* substrings) const {
-  if (args_->hashOnly) {
+  if ((args_->mode == mode_name::floret)) {
     std::vector<uint32_t> hashes;
     murmurhash(word, &hashes);
     for (uint32_t hash : hashes) {
@@ -205,7 +205,7 @@ void Dictionary::computeSubwords(
         ngram.push_back(word[j++]);
       }
       if (n >= args_->minn && !(n == 1 && (i == 0 || j == word.size()))) {
-        if (args_->hashOnly) {
+        if ((args_->mode == mode_name::floret)) {
           std::vector<uint32_t> hashes;
           murmurhash(ngram, &hashes);
           for (size_t i = 0; i < hashes.size(); i++) {
@@ -233,7 +233,7 @@ void Dictionary::initNgrams() {
       computeSubwords(word, words_[i].subwords);
     }
     // remove word-index subword for all words except 0 (</s>)
-    if (args_->hashOnly && i > 0) {
+    if ((args_->mode == mode_name::floret) && i > 0) {
       words_[i].subwords.erase(words_[i].subwords.begin());
     }
   }

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -96,7 +96,7 @@ int32_t FastText::getWordId(const std::string& word) const {
 }
 
 int32_t FastText::getSubwordId(const std::string& subword) const {
-  if (args_->hashOnly) {
+  if (args_->mode == mode_name::floret) {
     return -1;
   } else {
     int32_t h = dict_->hash(subword) % args_->bucket;
@@ -125,7 +125,7 @@ void FastText::getWordVector(Vector& vec, const std::string& word) const {
 
 void FastText::getSubwordVector(Vector& vec, const std::string& subword) const {
   vec.zero();
-  if (args_->hashOnly) {
+  if (args_->mode == mode_name::floret) {
     std::vector<uint32_t> hashes;
     dict_->murmurhash(subword, &hashes);
     for (size_t i = 0; i < hashes.size(); i++) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -381,7 +381,7 @@ void train(const std::vector<std::string> args) {
   }
   fasttext->saveModel(outputFileName);
   fasttext->saveVectors(a.output + ".vec");
-  if (a.hashOnly) {
+  if (a.mode == mode_name::floret) {
     fasttext->saveHashOnlyVectors(a.output + ".floret");
   }
   if (a.saveOutput) {


### PR DESCRIPTION
In parallel to `spacy init vectors --mode floret`, rename the boolean option `-hashOnly` to `-mode floret` with the default `-mode fasttext`.