### PR TITLE
Python 3.13 support, including a needed C++ #include directive

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
           python -m pip install wheel
 
       - name: Install fasttext
-        if: "!(startsWith(matrix.os, 'windows') && (matrix.python_version == '3.10' || matrix.python_version == '3.11') || matrix.python_version == '3.12')"
+        if: "!(startsWith(matrix.os, 'windows') && (matrix.python_version == '3.10' || matrix.python_version == '3.11') || matrix.python_version == '3.12' || matrix.python_version == '3.13')"
         run: |
           python -m pip install fasttext
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: windows-2019
             python_version: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,11 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 import os
-import subprocess
 import platform
 import io
 import pybind11
 
-__version__ = '0.10.5'
+__version__ = '0.10.6'
 FASTTEXT_SRC = "src"
 
 # Based on https://github.com/pybind/python_example
@@ -174,6 +173,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development',
         'Topic :: Scientific/Engineering',
         'Operating System :: Microsoft :: Windows',

--- a/src/args.cc
+++ b/src/args.cc
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 namespace fasttext {
 


### PR DESCRIPTION
Fixes #31 

Added #include that allows src/ to compile, and include 3.13 in targetted Python versions